### PR TITLE
Fix: Don't submit form when picking month

### DIFF
--- a/src/components/view/date-view/NavBar.svelte
+++ b/src/components/view/date-view/NavBar.svelte
@@ -85,6 +85,7 @@ function increment (direction, entity) {
         <button 
           class="month-selector--month" 
           class:selected={index === $displayedDate.month()}
+          type="button"
           disabled={!monthDefinition.selectable}
           on:click={e => monthSelected(e, { monthDefinition, index })}
         >


### PR DESCRIPTION
## Expected
When I
1. click on the current month, and then
2. click on a different month in the year overview

Then I expect
1. the month view for that month to open and
2. the underlying form NOT to be submitted

## Actual
Form is submitted when month button in year view is clicked.